### PR TITLE
RSpec and activesupport are not dev dependencies

### DIFF
--- a/rspec-partial-hash.gemspec
+++ b/rspec-partial-hash.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "activesupport", '>= 3.0'
-  spec.add_development_dependency "rspec"
+  
+  spec.add_dependency "rspec"
+  spec.add_dependency "activesupport", '>= 3.0'
 end


### PR DESCRIPTION
The gem won't work without them, so you should declare them as real dependencies. Not everybody writing ruby is doing Rails dev :)
